### PR TITLE
Add fish shell support

### DIFF
--- a/histree.fish
+++ b/histree.fish
@@ -1,0 +1,68 @@
+#!/usr/bin/env fish
+
+# Set default configuration paths and values
+set -g HISTREE_HOME (dirname (status -f))
+set -g HISTREE_BIN "$HISTREE_HOME/bin/histree"
+set -g HISTREE_DB (set -q HISTREE_DB; and echo $HISTREE_DB; or echo "$HOME/.histree.db")
+set -g HISTREE_LIMIT (set -q HISTREE_LIMIT; and echo $HISTREE_LIMIT; or echo 100)
+
+# Build the binary if it doesn't exist
+if not test -x $HISTREE_BIN
+    echo "Building histree..."
+    pushd $HISTREE_HOME
+    go build -o bin/histree ./cmd/histree
+    popd
+end
+
+# Generate unique session label when the plugin is loaded
+set -g _HISTREE_START_TIME (date +"%Y%m%d-%H%M%S")
+set -g _HISTREE_SESSION_LABEL (hostname):$_HISTREE_START_TIME:$$
+
+# Function to add a command to history
+function _histree_add_command
+    set -l cmd $_HISTREE_LAST_CMD
+    set -l exit_code $_HISTREE_LAST_EXIT_CODE
+
+    # If the command is empty, do not record it
+    if test -z "$cmd"
+        return
+    end
+
+    echo "$cmd" | $HISTREE_BIN -db "$HISTREE_DB" -action add -dir "$PWD" \
+        -session "$_HISTREE_SESSION_LABEL" \
+        -exit "$exit_code"
+end
+
+# Function to capture the last command
+function _histree_preexec --on-event fish_preexec
+    set -g _HISTREE_LAST_CMD $argv
+end
+
+# Function to capture the last exit code
+function _histree_precmd --on-event fish_prompt
+    set -g _HISTREE_LAST_EXIT_CODE $status
+    _histree_add_command
+end
+
+# Function to display history
+function histree
+    set -l format "simple"
+    set -l verbose false
+    set -l json false
+
+    for arg in $argv
+        switch $arg
+            case -v --verbose
+                set format "verbose"
+                set verbose true
+            case -json --json
+                set format "json"
+                set json true
+        end
+    end
+
+    $HISTREE_BIN -db "$HISTREE_DB" -action get -limit "$HISTREE_LIMIT" -dir "$PWD" -format "$format"
+end
+
+# Add aliases for showing history
+alias histree='histree'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,30 +7,58 @@ set -e
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET_DIR="${HOME}/.zsh-histree"
 
-echo "Installing zsh-histree to ${TARGET_DIR} ..."
+# Check if the shell is fish
+if [[ "$SHELL" == *"fish" ]]; then
+    TARGET_DIR="${HOME}/.fish-histree"
+    echo "Installing fish-histree to ${TARGET_DIR} ..."
 
-# Create target directory and copy files
-mkdir -p "${TARGET_DIR}/bin"
-cp -r "${INSTALL_DIR}/histree.zsh" "${TARGET_DIR}/"
-cp bin/histree "${TARGET_DIR}/bin/"
+    # Create target directory and copy files
+    mkdir -p "${TARGET_DIR}/bin"
+    cp -r "${INSTALL_DIR}/histree.fish" "${TARGET_DIR}/"
+    cp bin/histree "${TARGET_DIR}/bin/"
 
-# Add configuration to .zshrc if not already present
-ZSHRC="${HOME}/.zshrc"
-SOURCE_LINE="source ${TARGET_DIR}/histree.zsh"
+    # Add configuration to config.fish if not already present
+    CONFIG_FISH="${HOME}/.config/fish/config.fish"
+    SOURCE_LINE="source ${TARGET_DIR}/histree.fish"
 
-# Default configurations
-DB_CONFIG="export HISTREE_DB=\"\${HOME}/.histree.db\""
-LIMIT_CONFIG="export HISTREE_LIMIT=100"
+    if grep -qF "$SOURCE_LINE" "${CONFIG_FISH}"; then
+        echo "Your config.fish already sources fish-histree."
+    else
+        echo "" >> "${CONFIG_FISH}"
+        echo "# fish-histree configuration" >> "${CONFIG_FISH}"
+        echo "set -g HISTREE_DB \"\$HOME/.histree.db\"" >> "${CONFIG_FISH}"
+        echo "set -g HISTREE_LIMIT 100" >> "${CONFIG_FISH}"
+        echo "$SOURCE_LINE" >> "${CONFIG_FISH}"
+        echo "Added configuration to ${CONFIG_FISH}."
+    fi
 
-if grep -qF "$SOURCE_LINE" "${ZSHRC}"; then
-    echo "Your .zshrc already sources zsh-histree."
+    echo "Installation complete. Please restart your terminal or run 'source ~/.config/fish/config.fish' to activate fish-histree."
 else
-    echo "" >> "${ZSHRC}"
-    echo "# zsh-histree configuration" >> "${ZSHRC}"
-    echo "$DB_CONFIG" >> "${ZSHRC}"
-    echo "$LIMIT_CONFIG" >> "${ZSHRC}"
-    echo "$SOURCE_LINE" >> "${ZSHRC}"
-    echo "Added configuration to ${ZSHRC}."
-fi
+    echo "Installing zsh-histree to ${TARGET_DIR} ..."
 
-echo "Installation complete. Please restart your terminal or run 'source ~/.zshrc' to activate zsh-histree."
+    # Create target directory and copy files
+    mkdir -p "${TARGET_DIR}/bin"
+    cp -r "${INSTALL_DIR}/histree.zsh" "${TARGET_DIR}/"
+    cp bin/histree "${TARGET_DIR}/bin/"
+
+    # Add configuration to .zshrc if not already present
+    ZSHRC="${HOME}/.zshrc"
+    SOURCE_LINE="source ${TARGET_DIR}/histree.zsh"
+
+    # Default configurations
+    DB_CONFIG="export HISTREE_DB=\"\${HOME}/.histree.db\""
+    LIMIT_CONFIG="export HISTREE_LIMIT=100"
+
+    if grep -qF "$SOURCE_LINE" "${ZSHRC}"; then
+        echo "Your .zshrc already sources zsh-histree."
+    else
+        echo "" >> "${ZSHRC}"
+        echo "# zsh-histree configuration" >> "${ZSHRC}"
+        echo "$DB_CONFIG" >> "${ZSHRC}"
+        echo "$LIMIT_CONFIG" >> "${ZSHRC}"
+        echo "$SOURCE_LINE" >> "${ZSHRC}"
+        echo "Added configuration to ${ZSHRC}."
+    fi
+
+    echo "Installation complete. Please restart your terminal or run 'source ~/.zshrc' to activate zsh-histree."
+fi


### PR DESCRIPTION
Fixes #1

Add support for fish shell.

* Add `histree.fish` script for fish shell support.
* Modify `scripts/install.sh` to include fish shell installation.
* Check if `$SHELL` is fish and run fish install mode.
* Copy `histree.fish` to the target directory.
* Add configuration to `config.fish` if not already present.
* When fish mode, do not run zsh installer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ssig33/histree/pull/2?shareId=6810409f-5ea1-4b8b-a2f4-742a06de3d7a).